### PR TITLE
Pass failing operation to failure(NSError*) block.

### DIFF
--- a/GROAuth2SessionManager/GROAuth2SessionManager.h
+++ b/GROAuth2SessionManager/GROAuth2SessionManager.h
@@ -176,3 +176,17 @@
 - (void)authenticateUsingOAuthWithPath:(NSString *)path parameters:(NSDictionary *)parameters success:(void (^)(AFOAuthCredential *credential))success failure:(void (^)(NSError *error))failure;
 
 @end
+
+///----------------
+/// @name Constants
+///----------------
+
+/**
+ ## Error Information Keys
+
+  The following key is given in the `userInfo` dictionary of the NSError object passeed to the `failure` block object executed when a request operation finished unsuccessfully.
+
+
+ `kGROAuth2ErrorFailingOperationKey`: The failing AFHTTPRequestOperation object.
+ */
+extern NSString * const kGROAuthErrorFailingOperationKey;

--- a/GROAuth2SessionManager/GROAuth2SessionManager.m
+++ b/GROAuth2SessionManager/GROAuth2SessionManager.m
@@ -27,6 +27,7 @@ NSString * const kGROAuthCodeGrantType = @"authorization_code";
 NSString * const kGROAuthClientCredentialsGrantType = @"client_credentials";
 NSString * const kGROAuthPasswordCredentialsGrantType = @"password";
 NSString * const kGROAuthRefreshGrantType = @"refresh_token";
+NSString * const kGROAuthErrorFailingOperationKey = @"GROAuthErrorFailingOperation";
 
 #pragma mark GROAuth2SessionManager (Private)
 
@@ -191,6 +192,11 @@ NSString * const kGROAuthRefreshGrantType = @"refresh_token";
         }
     } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
+            if(error) {
+                NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
+                userInfo[kGROAuthErrorFailingOperationKey] = operation;
+                error = [NSError errorWithDomain:error.domain code:error.code userInfo:userInfo];
+            }
             failure(error);
         }
     }];


### PR DESCRIPTION
This allows upstream error handling to access e.g. the original request or response headers and body.
