### PR TITLE
Expose the session configuration.

### DIFF
--- a/GROAuth2SessionManager/GROAuth2SessionManager.h
+++ b/GROAuth2SessionManager/GROAuth2SessionManager.h
@@ -112,6 +112,21 @@
 - (id)initWithBaseURL:(NSURL *)url oAuthURL:(NSURL *)oAuthURL clientID:(NSString *)clientID secret:(NSString *)secret;
 
 /**
+ Initializes an `GROAuth2SessionManager` object with the specified base URL, client identifier, and secret.
+
+This is the designated initializer.
+
+ @param url The base URL for the HTTP client. This argument must not be `nil`.
+ @param configuration The configuration used to create the managed session.
+ @param oAuthURL The OAuth URL for the HTTP client if different than the base URL.
+ @param clientID The client identifier issued by the authorization server, uniquely representing the registration information provided by the client.
+ @param secret The client secret.
+
+ @return The newly-initialized OAuth 2 manager
+ */
+- (id)initWithBaseURL:(NSURL *)url sessionConfiguration:(NSURLSessionConfiguration *)configuration oAuthURL:(NSURL *)oAuthURL clientID:(NSString *)clientID secret:(NSString *)secret;
+
+/**
  Sets the "Authorization" HTTP header set in request objects made by the HTTP client to a basic authentication value with Base64-encoded username and password. This overwrites any existing value for this header.
 
  @param credential The OAuth credential

--- a/GROAuth2SessionManager/GROAuth2SessionManager.m
+++ b/GROAuth2SessionManager/GROAuth2SessionManager.m
@@ -58,9 +58,13 @@ NSString * const kGROAuthRefreshGrantType = @"refresh_token";
 }
 
 - (id)initWithBaseURL:(NSURL *)url oAuthURL:(NSURL *)oAuthURL clientID:(NSString *)clientID secret:(NSString *)secret {
+    return [self initWithBaseURL:url sessionConfiguration:nil oAuthURL:oAuthURL clientID:clientID secret:secret];
+}
+
+- (id)initWithBaseURL:(NSURL *)url sessionConfiguration:(NSURLSessionConfiguration *)configuration oAuthURL:(NSURL *)oAuthURL clientID:(NSString *)clientID secret:(NSString *)secret {
     NSParameterAssert(clientID);
 
-    self = [super initWithBaseURL:url];
+    self = [super initWithBaseURL:url sessionConfiguration:configuration];
     if (self) {
         [self setServiceProviderIdentifier:[[self baseURL] host]];
         [self setClientID:clientID];


### PR DESCRIPTION
I know it adds another parameter to the initializer but I would like to have access to the session configuration when using the GROAuth2SessionManager.  In the current implementation, there was no way to use a custom NSURLSessionConfiguration.
