### PR TITLE
remove nslog at retrieveCredentialWithIdentifier

### DIFF
--- a/GROAuth2SessionManager/AFOAuthCredential.m
+++ b/GROAuth2SessionManager/AFOAuthCredential.m
@@ -179,7 +179,6 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)queryDictionary, (CFTypeRef *)&result);
 
     if (status != errSecSuccess) {
-        NSLog(@"Unable to fetch credential with identifier \"%@\" (Error %li)", identifier, (long int)status);
         return nil;
     }
 

--- a/GROAuth2SessionManager/GROAuth2SessionManager.h
+++ b/GROAuth2SessionManager/GROAuth2SessionManager.h
@@ -33,7 +33,7 @@
 
 /**
  `GROAuth2SessionManager` encapsulates common patterns to authenticate against a resource server conforming to the behavior outlined in the OAuth 2.0 specification.
-
+ 
  @see RFC 6749 The OAuth 2.0 Authorization Framework: http://tools.ietf.org/html/rfc6749
  */
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0
@@ -67,53 +67,53 @@
 
 /**
  Creates and initializes an `GROAuth2SessionManager` object with the specified base URL, client identifier, and secret.
-
+ 
  @param url The base URL for the HTTP client. This argument must not be `nil`.
  @param clientID The client identifier issued by the authorization server, uniquely representing the registration information provided by the client.
  @param secret The client secret.
-
+ 
  @return The newly-initialized OAuth 2 manager
  */
 + (instancetype)managerWithBaseURL:(NSURL *)url clientID:(NSString *)clientID secret:(NSString *)secret;
 
 /**
  Creates and initializes an `GROAuth2SessionManager` object with the specified base URL, client identifier, and secret.
-
+ 
  @param url The base URL for the HTTP client. This argument must not be `nil`.
  @param oAuthURL The OAuth URL for the HTTP client if different than the base URL.
  @param clientID The client identifier issued by the authorization server, uniquely representing the registration information provided by the client.
  @param secret The client secret.
-
+ 
  @return The newly-initialized OAuth 2 manager
  */
 + (instancetype)managerWithBaseURL:(NSURL *)url oAuthURL:(NSURL *)oAuthURL clientID:(NSString *)clientID secret:(NSString *)secret;
 
 /**
  Initializes an `GROAuth2SessionManager` object with the specified base URL, client identifier, and secret.
-
+ 
  @param url The base URL for the HTTP client. This argument must not be `nil`.
  @param clientID The client identifier issued by the authorization server, uniquely representing the registration information provided by the client.
  @param secret The client secret.
-
+ 
  @return The newly-initialized OAuth 2 manager
  */
 - (id)initWithBaseURL:(NSURL *)url clientID:(NSString *)clientID secret:(NSString *)secret;
 
 /**
  Initializes an `GROAuth2SessionManager` object with the specified base URL, client identifier, and secret.
-
+ 
  @param url The base URL for the HTTP client. This argument must not be `nil`.
  @param oAuthURL The OAuth URL for the HTTP client if different than the base URL.
  @param clientID The client identifier issued by the authorization server, uniquely representing the registration information provided by the client.
  @param secret The client secret.
-
+ 
  @return The newly-initialized OAuth 2 manager
  */
 - (id)initWithBaseURL:(NSURL *)url oAuthURL:(NSURL *)oAuthURL clientID:(NSString *)clientID secret:(NSString *)secret;
 
 /**
  Sets the "Authorization" HTTP header set in request objects made by the HTTP client to a basic authentication value with Base64-encoded username and password. This overwrites any existing value for this header.
-
+ 
  @param credential The OAuth credential
  */
 - (void)setAuthorizationHeaderWithCredential:(AFOAuthCredential *)credential;
@@ -124,7 +124,7 @@
 
 /**
  Creates and enqueues an `AFHTTPRequestOperation` to authenticate against the server using a specified username and password, with a designated scope.
-
+ 
  @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param username The username used for authentication
  @param password The password used for authentication
@@ -132,47 +132,47 @@
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
-- (void)authenticateUsingOAuthWithPath:(NSString *)path username:(NSString *)username password:(NSString *)password scope:(NSString *)scope success:(void (^)(AFOAuthCredential *credential))success failure:(void (^)(NSError *error))failure;
+- (void)authenticateUsingOAuthWithPath:(NSString *)path username:(NSString *)username password:(NSString *)password scope:(NSString *)scope success:(void (^)(AFOAuthCredential *credential))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
 /**
  Creates and enqueues an `AFHTTPRequestOperation` to authenticate against the server with a designated scope.
-
+ 
  @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param scope The authorization scope
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
-- (void)authenticateUsingOAuthWithPath:(NSString *)path scope:(NSString *)scope success:(void (^)(AFOAuthCredential *credential))success failure:(void (^)(NSError *error))failure;
+- (void)authenticateUsingOAuthWithPath:(NSString *)path scope:(NSString *)scope success:(void (^)(AFOAuthCredential *credential))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
 /**
  Creates and enqueues an `AFHTTPRequestOperation` to authenticate against the server using the specified refresh token.
-
+ 
  @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param refreshToken The OAuth refresh token
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
-- (void)authenticateUsingOAuthWithPath:(NSString *)path refreshToken:(NSString *)refreshToken success:(void (^)(AFOAuthCredential *credential))success failure:(void (^)(NSError *error))failure;
+- (void)authenticateUsingOAuthWithPath:(NSString *)path refreshToken:(NSString *)refreshToken success:(void (^)(AFOAuthCredential *credential))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
 /**
  Creates and enqueues an `AFHTTPRequestOperation` to authenticate against the server with an authorization code, redirecting to a specified URI upon successful authentication.
-
+ 
  @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param code The authorization code
  @param redirectURI The URI to redirect to after successful authentication
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
-- (void)authenticateUsingOAuthWithPath:(NSString *)path code:(NSString *)code redirectURI:(NSString *)redirectURI success:(void (^)(AFOAuthCredential *credential))success failure:(void (^)(NSError *error))failure;
+- (void)authenticateUsingOAuthWithPath:(NSString *)path code:(NSString *)code redirectURI:(NSString *)redirectURI success:(void (^)(AFOAuthCredential *credential))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
 /**
  Creates and enqueues an `AFHTTPRequestOperation` to authenticate against the server with the specified parameters.
-
+ 
  @param path The path to be appended to the HTTP client's base URL and used as the request URL.
  @param parameters The parameters to be encoded and set in the request HTTP body.
  @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes a single argument: the OAuth credential returned by the server.
  @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the response data. This block has no return value and takes a single argument: the error returned from the server.
  */
-- (void)authenticateUsingOAuthWithPath:(NSString *)path parameters:(NSDictionary *)parameters success:(void (^)(AFOAuthCredential *credential))success failure:(void (^)(NSError *error))failure;
+- (void)authenticateUsingOAuthWithPath:(NSString *)path parameters:(NSDictionary *)parameters success:(void (^)(AFOAuthCredential *credential))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
 
 @end

--- a/GROAuth2SessionManager/GROAuth2SessionManager.m
+++ b/GROAuth2SessionManager/GROAuth2SessionManager.m
@@ -59,7 +59,7 @@ NSString * const kGROAuthRefreshGrantType = @"refresh_token";
 
 - (id)initWithBaseURL:(NSURL *)url oAuthURL:(NSURL *)oAuthURL clientID:(NSString *)clientID secret:(NSString *)secret {
     NSParameterAssert(clientID);
-
+	
     self = [super initWithBaseURL:url];
     if (self) {
         [self setServiceProviderIdentifier:[[self baseURL] host]];
@@ -67,7 +67,7 @@ NSString * const kGROAuthRefreshGrantType = @"refresh_token";
         [self setSecret:secret];
         [self setOAuthURL:oAuthURL];
     }
-
+	
     return self;
 }
 
@@ -91,71 +91,71 @@ NSString * const kGROAuthRefreshGrantType = @"refresh_token";
 
 #pragma mark - Authentication
 
-- (void)authenticateUsingOAuthWithPath:(NSString *)path username:(NSString *)username password:(NSString *)password scope:(NSString *)scope success:(void (^)(AFOAuthCredential *))success failure:(void (^)(NSError *))failure {
+- (void)authenticateUsingOAuthWithPath:(NSString *)path username:(NSString *)username password:(NSString *)password scope:(NSString *)scope success:(void (^)(AFOAuthCredential *))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *))failure {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionary];
     [mutableParameters setObject:kGROAuthPasswordCredentialsGrantType forKey:@"grant_type"];
     [mutableParameters setValue:username forKey:@"username"];
     [mutableParameters setValue:password forKey:@"password"];
     [mutableParameters setValue:scope forKey:@"scope"];
-
+	
     NSDictionary *parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
-
+	
     [self authenticateUsingOAuthWithPath:path parameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithPath:(NSString *)path scope:(NSString *)scope success:(void (^)(AFOAuthCredential *))success failure:(void (^)(NSError *))failure {
+- (void)authenticateUsingOAuthWithPath:(NSString *)path scope:(NSString *)scope success:(void (^)(AFOAuthCredential *))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *))failure {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionary];
     [mutableParameters setObject:kGROAuthClientCredentialsGrantType forKey:@"grant_type"];
     [mutableParameters setValue:scope forKey:@"scope"];
-
+	
     NSDictionary *parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
-
+	
     [self authenticateUsingOAuthWithPath:path parameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithPath:(NSString *)path refreshToken:(NSString *)refreshToken success:(void (^)(AFOAuthCredential *))success failure:(void (^)(NSError *))failure {
+- (void)authenticateUsingOAuthWithPath:(NSString *)path refreshToken:(NSString *)refreshToken success:(void (^)(AFOAuthCredential *))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *))failure {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionary];
     [mutableParameters setObject:kGROAuthRefreshGrantType forKey:@"grant_type"];
     [mutableParameters setValue:refreshToken forKey:@"refresh_token"];
-
+	
     NSDictionary *parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
-
+	
     [self authenticateUsingOAuthWithPath:path parameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithPath:(NSString *)path code:(NSString *)code redirectURI:(NSString *)redirectURI success:(void (^)(AFOAuthCredential *))success failure:(void (^)(NSError *))failure {
+- (void)authenticateUsingOAuthWithPath:(NSString *)path code:(NSString *)code redirectURI:(NSString *)redirectURI success:(void (^)(AFOAuthCredential *))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *))failure {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionary];
     [mutableParameters setObject:kGROAuthCodeGrantType forKey:@"grant_type"];
     [mutableParameters setValue:code forKey:@"code"];
     [mutableParameters setValue:redirectURI forKey:@"redirect_uri"];
-
+	
     NSDictionary *parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
-
+	
     [self authenticateUsingOAuthWithPath:path parameters:parameters success:success failure:failure];
 }
 
-- (void)authenticateUsingOAuthWithPath:(NSString *)path parameters:(NSDictionary *)parameters success:(void (^)(AFOAuthCredential *))success failure:(void (^)(NSError *))failure {
+- (void)authenticateUsingOAuthWithPath:(NSString *)path parameters:(NSDictionary *)parameters success:(void (^)(AFOAuthCredential *))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *))failure {
     NSMutableDictionary *mutableParameters = [NSMutableDictionary dictionaryWithDictionary:parameters];
     [mutableParameters setObject:[self clientID] forKey:@"client_id"];
     [mutableParameters setValue:[self secret] forKey:@"client_secret"];
-
+	
     parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
-
+	
     NSString *urlString;
     if ([self oAuthURL]) {
         urlString = [[NSURL URLWithString:path relativeToURL:[self oAuthURL]] absoluteString];
     } else {
         urlString = [[NSURL URLWithString:path relativeToURL:[self baseURL]] absoluteString];
     }
-
+	
     NSError *error;
     NSMutableURLRequest *mutableRequest = [[AFHTTPRequestSerializer serializer] requestWithMethod:@"POST" URLString:urlString parameters:parameters error:&error];
     if (error) {
-        failure(error);
-
+        failure(nil, error);
+		
         return;
     }
-
+	
     AFHTTPRequestOperation *requestOperation = [[AFHTTPRequestOperation alloc] initWithRequest:mutableRequest];
     [requestOperation setResponseSerializer:[AFJSONResponseSerializer serializer]];
     [requestOperation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -163,38 +163,38 @@ NSString * const kGROAuthRefreshGrantType = @"refresh_token";
             if (failure) {
                 // TODO: Resolve the `error` field into a proper NSError object
                 // http://tools.ietf.org/html/rfc6749#section-5.2
-                failure(nil);
+                failure(operation, nil);
             }
-
+			
             return;
         }
-
+		
         NSString *refreshToken = [responseObject valueForKey:@"refresh_token"];
         if (refreshToken == nil || [refreshToken isEqual:[NSNull null]]) {
             refreshToken = [parameters valueForKey:@"refresh_token"];
         }
-
+		
         AFOAuthCredential *credential = [AFOAuthCredential credentialWithOAuthToken:[responseObject valueForKey:@"access_token"] tokenType:[responseObject valueForKey:@"token_type"]];
-
+		
         NSDate *expireDate = [NSDate distantFuture];
         id expiresIn = [responseObject valueForKey:@"expires_in"];
         if (expiresIn != nil && ![expiresIn isEqual:[NSNull null]]) {
             expireDate = [NSDate dateWithTimeIntervalSinceNow:[expiresIn doubleValue]];
         }
-
+		
         [credential setRefreshToken:refreshToken expiration:expireDate];
-
+		
         [self setAuthorizationHeaderWithCredential:credential];
-
+		
         if (success) {
             success(credential);
         }
     } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
         if (failure) {
-            failure(error);
+            failure(operation, error);
         }
     }];
-
+	
     [requestOperation start];
 }
 


### PR DESCRIPTION
Hey Gabriel, i would prefer to remove NSLog from the retrieveCredentialWithIdentifier method. 
so you can check if a credential is set or not without a warning . or is there another way to find out if a credential is set? 
