### PR TITLE
Upgrade AFNetworking to 2.5.0.

### DIFF
--- a/GROAuth2SessionManager.podspec
+++ b/GROAuth2SessionManager.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.9'
 
-  s.dependency 'AFNetworking', '~> 2.4.1'
+  s.dependency 'AFNetworking', '~> 2.5.0'
 
   s.ios.frameworks = 'Security'
 


### PR DESCRIPTION
This pull request simply updates the AFNetworking dependency to 2.5.0. Specifically I've been experiencing the following crash a lot, which is fixed in that version.

https://github.com/AFNetworking/AFNetworking/issues/1477
