### PR TITLE
decouple refreshToken and expiration properties.

### DIFF
--- a/GROAuth2SessionManager/AFOAuthCredential.h
+++ b/GROAuth2SessionManager/AFOAuthCredential.h
@@ -44,7 +44,12 @@
 /**
  The OAuth refresh token.
  */
-@property (readonly, nonatomic) NSString *refreshToken;
+@property (copy, nonatomic) NSString *refreshToken;
+
+/**
+ The expiration of the access token. This must not be `nil`.
+ */
+@property (strong, nonatomic) NSDate *expiration;
 
 /**
  Whether the OAuth credentials are expired.
@@ -84,7 +89,8 @@
  @param expiration The expiration of the access token. This must not be `nil`.
  */
 - (void)setRefreshToken:(NSString *)refreshToken
-             expiration:(NSDate *)expiration;
+             expiration:(NSDate *)expiration
+__deprecated_msg("use refreshToken and expiration instead.");
 
 ///-----------------------------------------
 /// @name Storing and Retrieving Credentials

--- a/GROAuth2SessionManager/AFOAuthCredential.m
+++ b/GROAuth2SessionManager/AFOAuthCredential.m
@@ -37,8 +37,6 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
 @interface AFOAuthCredential ()
 @property (readwrite, nonatomic) NSString *accessToken;
 @property (readwrite, nonatomic) NSString *tokenType;
-@property (readwrite, nonatomic) NSString *refreshToken;
-@property (readwrite, nonatomic) NSDate *expiration;
 @end
 
 @implementation AFOAuthCredential
@@ -77,12 +75,15 @@ static NSMutableDictionary * AFKeychainQueryDictionaryWithIdentifier(NSString *i
 - (void)setRefreshToken:(NSString *)refreshToken
              expiration:(NSDate *)expiration
 {
-    if (!refreshToken || !expiration) {
-        return;
-    }
-
     self.refreshToken = refreshToken;
     self.expiration = expiration;
+}
+
+- (void)setExpiration:(NSDate *)expiration
+{
+    NSParameterAssert(expiration);
+    
+    _expiration = expiration;
 }
 
 - (BOOL)isExpired {

--- a/GROAuth2SessionManager/GROAuth2SessionManager.m
+++ b/GROAuth2SessionManager/GROAuth2SessionManager.m
@@ -170,20 +170,22 @@ NSString * const kGROAuthErrorFailingOperationKey = @"GROAuthErrorFailingOperati
             return;
         }
 
+        AFOAuthCredential *credential = [AFOAuthCredential credentialWithOAuthToken:[responseObject valueForKey:@"access_token"] tokenType:[responseObject valueForKey:@"token_type"]];
+        
         NSString *refreshToken = [responseObject valueForKey:@"refresh_token"];
         if (refreshToken == nil || [refreshToken isEqual:[NSNull null]]) {
             refreshToken = [parameters valueForKey:@"refresh_token"];
         }
-
-        AFOAuthCredential *credential = [AFOAuthCredential credentialWithOAuthToken:[responseObject valueForKey:@"access_token"] tokenType:[responseObject valueForKey:@"token_type"]];
+        
+        credential.refreshToken = refreshToken;
 
         NSDate *expireDate = [NSDate distantFuture];
         id expiresIn = [responseObject valueForKey:@"expires_in"];
         if (expiresIn != nil && ![expiresIn isEqual:[NSNull null]]) {
             expireDate = [NSDate dateWithTimeIntervalSinceNow:[expiresIn doubleValue]];
         }
-
-        [credential setRefreshToken:refreshToken expiration:expireDate];
+        
+        credential.expiration = expireDate;
 
         [self setAuthorizationHeaderWithCredential:credential];
 


### PR DESCRIPTION
Mark setRefreshToken:expiration: as deprecated.

Fixes https://github.com/gabrielrinaldi/GROAuth2SessionManager/issues/24 and https://github.com/gabrielrinaldi/GROAuth2SessionManager/commit/4aea793623fe416a696511e4d6522b10e8b97e48
